### PR TITLE
S3 2.0 - Round 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Function|NAnt Task|Comment
 Uploading a file|amazon-s3-putFile|
 Uploading a file|amazon-s3|(DEPRECATED - for backwards compatibility only)
 Downloading a file|amazon-s3-getFile|
+Copy a file between buckets|amazon-s3-copyFile|
 Deleting a file|amazon-s3-deleteFile|
 Creating a bucket|amazon-s3-CreateBucket|
 Deleting a bucket|amazon-s3-DeleteBucket|

--- a/README.md
+++ b/README.md
@@ -5,7 +5,19 @@ This repository contains a Visual Studio 2010 solution with three projects:
 
 S3NAntTask
 ----------
-This project contains a NAnt task for sending files to an Amazon S3 bucket. The task will check to see if the bucket exists before sending the file. If the bucket doesn't exist, it will create the bucket before sending the file.
+
+This project contains custom NAnt tasks for:
+
+Function|NAnt Task|Comment
+--------|---------|-------
+Uploading a file|amazon-s3-putFile|
+Uploading a file|amazon-s3|(DEPRECATED - for backwards compatibility only)
+Downloading a file|amazon-s3-getFile|
+Deleting a file|amazon-s3-deleteFile|
+Creating a bucket|amazon-s3-CreateBucket|
+Deleting a bucket|amazon-s3-DeleteBucket|
+
+
 
 Desired improvements:
 The ability to list multiple files (fileset)  to send to an s3 bucket rather than one at a time

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ Uploading a file|amazon-s3|(DEPRECATED - for backwards compatibility only)
 Downloading a file|amazon-s3-getFile|
 Copy a file between buckets|amazon-s3-copyFile|
 Deleting a file|amazon-s3-deleteFile|
+Deleting all files in a bucket|amazon-s3-deleteAllFiles|
 Creating a bucket|amazon-s3-CreateBucket|
 Deleting a bucket|amazon-s3-DeleteBucket|
 
-
+NOTE: Review default.build for usage of tasks
 
 Desired improvements:
 The ability to list multiple files (fileset)  to send to an s3 bucket rather than one at a time

--- a/S3NAntTask/Default.build
+++ b/S3NAntTask/Default.build
@@ -75,18 +75,17 @@
             bucket      = "${bucket}" 
             file        = "${file}"/>
         
-        <amazon-s3-deleteFile
-            accesskey   = "${AWS_ACCESS_Key}"
-            secretkey   = "${AWS_SECRET_Key}"
-            bucket      = "${bucket}"
-            file        = "${file1}"/>
+    </target>
 
-        <amazon-s3-deleteFile
+    <target name="delete-all-files" description="Test the delete all files in a bucket">
+        <!-- In the following task, searchstring is the string to look for in the object keys to delete.
+             If left blank this task will delete all the files in the specified bucket.-->
+        <amazon-s3-deleteAllFiles
             accesskey   = "${AWS_ACCESS_Key}"
             secretkey   = "${AWS_SECRET_Key}"
             bucket      = "${bucket}"
-            file        = '${TargetFile}'/>
-        
+            searchstring = "" />
+
     </target>
 
     <target name="delete-bucket" description="Test the Amazon S3 NAnt delete bucket task">
@@ -105,6 +104,7 @@
         <call target="copy" />
         <call target="get" />
         <call target="delete-files" />
+        <call target="delete-all-files" />
         <call target="delete-bucket" />
     </target>
     

--- a/S3NAntTask/Default.build
+++ b/S3NAntTask/Default.build
@@ -6,10 +6,11 @@
     <property name="AWS_SECRET_Key" value="" />
     
     <property name="current.directory"	value="${directory::get-current-directory()}" />
-    <property name="bucket"             value="S3NAntTask-test-bucket" />
+    <property name="bucket"             value="" />
     <property name="file"               value="file.zip" />
     <property name="file1"              value="file1.zip" />
     <property name="Outputfile"         value="file2.zip" />
+    <property name="TargetFile"         value='test/file3.zip' />
 
 
     <target name="put" description="Test the Amazon S3 NAnt upload task">
@@ -18,7 +19,9 @@
             accesskey   = "${AWS_ACCESS_Key}" 
             secretkey   = "${AWS_SECRET_Key}" 
             bucket      = "${bucket}" 
-            file        = "${current.directory}\${file}" />
+            file        = "${current.directory}\${file}" 
+            key         = "${file}"
+            overwrite   = "true" />
     
     </target>
 
@@ -43,6 +46,18 @@
 
     </target>
 
+    <target name="copy" description="Test the AWS S3 NAnt copy task">
+        
+        <amazon-s3-copyFile
+            accesskey   = "${AWS_ACCESS_Key}"
+            secretkey   = "${AWS_SECRET_Key}"
+            bucket      = "${bucket}"
+            targetBucket = "${bucket}"
+            sourceFile   = "${file1}"
+            targetFile   = "${TargetFile}" />
+
+    </target>
+
     <target name="create-bucket" description="Test the Amazon S3 NAnt create bucket task">
 
         <amazon-s3-CreateBucket
@@ -52,7 +67,8 @@
 
     </target>
 
-    <target name="delete-file" description="Test the Amazon S3 NAnt delete file task" >
+    <target name="delete-files" description="Test the Amazon S3 NAnt delete file task" >
+
         <amazon-s3-deleteFile
             accesskey   = "${AWS_ACCESS_Key}"
             secretkey   = "${AWS_SECRET_Key}"
@@ -64,6 +80,12 @@
             secretkey   = "${AWS_SECRET_Key}"
             bucket      = "${bucket}"
             file        = "${file1}"/>
+
+        <amazon-s3-deleteFile
+            accesskey   = "${AWS_ACCESS_Key}"
+            secretkey   = "${AWS_SECRET_Key}"
+            bucket      = "${bucket}"
+            file        = '${TargetFile}'/>
         
     </target>
 
@@ -80,8 +102,9 @@
         <call target="create-bucket" />
         <call target="put" />
         <call target="put-DEPRECATED" />
+        <call target="copy" />
         <call target="get" />
-        <call target="delete-file" />
+        <call target="delete-files" />
         <call target="delete-bucket" />
     </target>
     

--- a/S3NAntTask/S3CopyFileTask.cs
+++ b/S3NAntTask/S3CopyFileTask.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Amazon.S3;
+using Amazon.S3.Model;
+using NAnt.Core;
+using NAnt.Core.Attributes;
+
+namespace S3NAntTask
+{
+    [TaskName("amazon-s3-copyFile")]
+    class S3CopyFileTask : S3CoreTask
+    {
+        #region Task Attributes
+
+        [TaskAttribute("sourceFile", Required = true)]
+        [StringValidator(AllowEmpty = false)]
+        public string sourceKey { get; set; }
+
+        [TaskAttribute("targetFile", Required = true)]
+        [StringValidator(AllowEmpty = false)]
+        public string targetKey { get; set; }
+
+        [TaskAttribute("targetBucket", Required = true)]
+        [StringValidator(AllowEmpty = false)]
+        public string TargetBucket { get; set; }
+
+        [TaskAttribute("overwrite", Required = false)]
+        [StringValidator(AllowEmpty = true)]
+        public bool Overwrite { get; set; }
+
+        #endregion
+
+        /// <summary>Execute the NAnt task</summary>
+        protected override void ExecuteTask()
+        {
+
+            // Ensure the configured bucket exists
+            if (!BucketExists(BucketName))
+            {
+                Project.Log(Level.Error, "[ERROR] S3 Bucket '{0}' not found!", BucketName);
+                return;
+            }
+
+            if (!BucketExists(TargetBucket))
+            {
+                Project.Log(Level.Error, "[ERROR] S3 Bucket '{0}' not found!", TargetBucket);
+                return;
+            }
+
+            try
+            {
+                Project.Log(Level.Info, "Copying: " + BucketName + ": " + sourceKey + " to " + TargetBucket + ": " + targetKey);
+                CopyObjectRequest request = new CopyObjectRequest
+                {
+                    SourceBucket = BucketName,
+                    SourceKey = sourceKey,
+                    DestinationBucket = TargetBucket,
+                    DestinationKey = targetKey
+                };
+                CopyObjectResponse response = Client.CopyObject(request);
+            }
+            catch (AmazonS3Exception ex)
+            {
+                Project.Log(Level.Error, "[ERROR] {0}: {1} \r\n{2}", ex.StatusCode, ex.Message, ex.InnerException);
+                return;
+            }
+
+            if (!FileExists(targetKey))
+                Project.Log(Level.Error, "Copy FAILED!");
+            else
+                Project.Log(Level.Info, "Copy successful!");
+        
+        }
+
+        /// <summary>Determine if our file already exists in the specified S3 bucket</summary>
+        /// <returns>True if the file already exists in the specified bucket</returns>
+        public bool FileExists(string fileKey)
+        {
+            using (Client)
+            {
+                try
+                {
+                    ListObjectsRequest request = new ListObjectsRequest
+                    {
+                        BucketName = BucketName
+                    };
+
+                    using (var response = Client.ListObjects(request))
+                    {
+                        foreach (var file in response.S3Objects)
+                        {
+                            if (file.Key.Equals(fileKey))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+                catch (AmazonS3Exception ex)
+                {
+                    ShowError(ex);
+                }
+            }
+            return false;
+        }
+
+    }
+}

--- a/S3NAntTask/S3CoreFileTask.cs
+++ b/S3NAntTask/S3CoreFileTask.cs
@@ -45,7 +45,7 @@ namespace S3NAntTask
 
         /// <summary>Determine if our file already exists in the specified S3 bucket</summary>
         /// <returns>True if the file already exists in the specified bucket</returns>
-        public bool FileExists()
+        public bool FileExists(string fileKey)
         {
             using (Client)
             {
@@ -60,7 +60,8 @@ namespace S3NAntTask
                     {
                         foreach (var file in response.S3Objects)
                         {
-                            if (file.Key.Equals(FileName))
+                            //Project.Log(Level.Info, "File: " + file.Key);
+                            if (file.Key.Equals(fileKey))
                             {
                                 return true;
                             }

--- a/S3NAntTask/S3CoreTask.cs
+++ b/S3NAntTask/S3CoreTask.cs
@@ -57,7 +57,7 @@ namespace S3NAntTask
 
         /// <summary>Determine if the specified bucket alredy exists</summary>
         /// <returns>True if the bucket exists</returns>
-        public bool BucketExists()
+        public bool BucketExists(string bucketName)
         {
             using (Client)
             {
@@ -65,7 +65,7 @@ namespace S3NAntTask
                 {
                     using (var response = Client.ListBuckets())
                     {
-                        if (response.Buckets.Any(bucket => bucket.BucketName.Equals(BucketName)))
+                        if (response.Buckets.Any(bucket => bucket.BucketName.Equals(bucketName)))
                         {
                             return true;
                         }

--- a/S3NAntTask/S3CreateBucketTask.cs
+++ b/S3NAntTask/S3CreateBucketTask.cs
@@ -14,16 +14,16 @@ namespace S3NAntTask
 
         protected override void ExecuteTask() 
         {
-            if (!BucketExists())
+            if (!BucketExists(BucketName))
                 CreateBucket();
             else
-                Project.Log(Level.Error, "Bucket already exists!", BucketName);
+                Project.Log(Level.Error, "Bucket: {0}, already exists!", BucketName);
         }
 
         /// <summary>Create the configured bucket</summary>
         public void CreateBucket()
         {
-            Project.Log(Level.Info, "Creating S3 bucket '{0}'", BucketName);
+            Project.Log(Level.Info, "Creating S3 bucket: {0}", BucketName);
             using (Client)
             {
                 try

--- a/S3NAntTask/S3DeleteBucketTask.cs
+++ b/S3NAntTask/S3DeleteBucketTask.cs
@@ -16,22 +16,30 @@ namespace S3NAntTask
         protected override void ExecuteTask()
         {
             Project.Log(Level.Info, "Deleting S3 bucket: {0}", BucketName);
-            using (Client)
+
+            /// Check to see if the bucket exists before we try to delete it. 
+            if (!BucketExists(BucketName))
             {
-                try
+                Project.Log(Level.Warning, "Bucket: {0} not found!", BucketName);
+                return;
+            }
+            else 
+            {
+                using (Client)
                 {
-                    DeleteBucketRequest request = new DeleteBucketRequest();
-                    request.BucketName = BucketName;
-                    //{
-                    //    BucketName = BucketName
-                    //};
-                    Client.DeleteBucket(request);
-                }
-                catch (AmazonS3Exception ex)
-                {
-                    ShowError(ex);
+                    try
+                    {
+                        DeleteBucketRequest request = new DeleteBucketRequest();
+                        request.BucketName = BucketName;
+                        Client.DeleteBucket(request);
+                    }
+                    catch (AmazonS3Exception ex)
+                    {
+                        ShowError(ex);
+                    }
                 }
             }
+            
         }
 
     }

--- a/S3NAntTask/S3DeleteFileTask.cs
+++ b/S3NAntTask/S3DeleteFileTask.cs
@@ -17,16 +17,16 @@ namespace S3NAntTask
         protected override void ExecuteTask()
         {
             // Ensure the configured bucket exists
-            if (!BucketExists())
+            if (!BucketExists(BucketName))
             {
-                Project.Log(Level.Error, "[ERROR] S3 Bucket '{0}' not found!", BucketName);
+                Project.Log(Level.Error, "[ERROR] S3 Bucket: {0}, not found!", BucketName);
                 return;
             }
 
             // Ensure the file exists
-            if (!FileExists())
+            if (!FileExists(FilePath))
             {
-                Project.Log(Level.Error, "File not found {0}", FileName);
+                Project.Log(Level.Error, "File not found {0}", FilePath);
                 return;
             }
             else
@@ -36,11 +36,11 @@ namespace S3NAntTask
                 {
                     try
                     {
-                        Project.Log(Level.Info, "Deleting file: {0}", FileName);
+                        Project.Log(Level.Info, "Deleting file: {0}", FilePath);
                         DeleteObjectRequest request = new DeleteObjectRequest
                         {
-                            Key = FileName,
-                            BucketName = BucketName,
+                            Key = FilePath,
+                            BucketName = BucketName
                         };
 
                         var response = Client.DeleteObject(request);
@@ -51,10 +51,10 @@ namespace S3NAntTask
                         ShowError(ex);
                     }
                 }
-                if (FileExists())
-                    Project.Log(Level.Error, "Delete file: {0} FAILED!", FileName);
+                if (FileExists(FilePath))
+                    Project.Log(Level.Error, "File delete FAILED!");
                 else
-                    Project.Log(Level.Info, "Delete file: {0} successful.", FileName);
+                    Project.Log(Level.Info, "File deleted.");
 
             }
         }

--- a/S3NAntTask/S3DeleteMultipleFilesTask.cs
+++ b/S3NAntTask/S3DeleteMultipleFilesTask.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Amazon.S3;
+using Amazon.S3.Model;
+using NAnt.Core;
+using NAnt.Core.Attributes;
+
+namespace S3NAntTask
+{
+    [TaskName("amazon-s3-deleteAllFiles")]
+    public class S3DeleteMultipleFilesTask : S3CoreTask
+    {
+        #region Task Attributes
+
+        [TaskAttribute("searchstring", Required = true)]
+        [StringValidator(AllowEmpty = true)]
+        public string SearchString { get; set; }
+
+        #endregion
+
+        DeleteObjectsRequest deleteRequest = new DeleteObjectsRequest();
+        int numKeys = 0;
+
+        /// <summary>Execute the NAnt task</summary>
+        protected override void ExecuteTask()
+        {
+            // Ensure the configured bucket exists
+            if (!BucketExists(BucketName))
+            {
+                Project.Log(Level.Error, "[ERROR] S3 Bucket: {0}, not found!", BucketName);
+                return;
+            }
+
+            deleteRequest.BucketName = BucketName;
+
+            FindKeys(BucketName, deleteRequest, SearchString, Client);
+
+            // Delete the file from S3
+            if (numKeys > 0)
+            {
+                if (String.IsNullOrEmpty(SearchString))
+                    SearchString = "NONE (all files will be deleted!)";
+
+                using (Client)
+                {
+                    try
+                    {
+                        DeleteObjectsResponse response = Client.DeleteObjects(deleteRequest);
+                        Project.Log(Level.Info, "Successfully deleted {0} files", response.DeletedObjects.Count);
+
+                    }
+                    catch (DeleteObjectsException ex)
+                    {
+                        ShowError(ex);
+                    }
+                    catch (AmazonS3Exception ex)
+                    {
+                        ShowError(ex);
+                    }
+                    catch (Exception ex)
+                    {
+                        Project.Log(Level.Error, "ERROR: " + ex.Message);
+                    }
+                }
+            }
+            else
+            {
+                Project.Log(Level.Info, "Bucket contains no files with the specified search string: {0}", SearchString);
+            }
+
+        }
+
+        private void FindKeys(string BucketName, DeleteObjectsRequest deleteRequest, string SearchString, AmazonS3 Client)
+        {
+            ListObjectsRequest request = new ListObjectsRequest
+            {
+                BucketName = BucketName
+            };
+
+            using (Client)
+            {
+                do
+                {
+
+                    ListObjectsResponse response = Client.ListObjects(request);
+                    foreach (S3Object entry in response.S3Objects)
+                    {
+                        if (entry.Key.Contains(SearchString))
+                        {
+                            Project.Log(Level.Info, "Deleting file: {0}", entry.Key);
+                            deleteRequest.AddKey(entry.Key, null);
+                            numKeys++;
+                        }
+                    }
+                    // If response is truncated, set the marker to get the next 
+                    // set of keys.
+                    if (response.IsTruncated)
+                    {
+                        request.Marker = response.NextMarker;
+                    }
+                    else
+                    {
+                        request = null;
+                    }
+
+                } while (request != null);
+            }
+        }
+
+    }
+}
+

--- a/S3NAntTask/S3GetFileTask.cs
+++ b/S3NAntTask/S3GetFileTask.cs
@@ -39,14 +39,14 @@ namespace S3NAntTask
         protected override void ExecuteTask() 
         {
             // Ensure the configured bucket exists
-            if (!BucketExists())
+            if (!BucketExists(BucketName))
             {
-                Project.Log(Level.Error, "[ERROR] S3 Bucket '{0}' not found!", BucketName);
+                Project.Log(Level.Error, "[ERROR] S3 Bucket: {0}, not found!", BucketName);
                 return;
             }
 
             // Ensure the file exists
-            if (!FileExists())
+            if (!FileExists(FileName))
             {
                 Project.Log(Level.Error, "File not found {0}", FileName);
                 return;
@@ -78,9 +78,9 @@ namespace S3NAntTask
             
             // verify that the file actually downloaded
             if (File.Exists(Outputfile))
-                Project.Log(Level.Info, "Download of '{0}' successful.", Outputfile);
+                Project.Log(Level.Info, "Download successful.", Outputfile);
             else
-                Project.Log(Level.Info, "Download of '{0}' FAILED!", Outputfile);
+                Project.Log(Level.Info, "Download FAILED!", Outputfile);
         }
     }
 }

--- a/S3NAntTask/S3NAntTask.csproj
+++ b/S3NAntTask/S3NAntTask.csproj
@@ -48,6 +48,7 @@
     <Compile Include="S3CoreFileTask.cs" />
     <Compile Include="S3CoreTask.cs" />
     <Compile Include="S3CreateBucketTask.cs" />
+    <Compile Include="S3DeleteMultipleFilesTask.cs" />
     <Compile Include="S3DeleteBucketTask.cs" />
     <Compile Include="S3DeleteFileTask.cs" />
     <Compile Include="S3GetFileTask.cs" />

--- a/S3NAntTask/S3NAntTask.csproj
+++ b/S3NAntTask/S3NAntTask.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="S3CopyFileTask.cs" />
     <Compile Include="S3CoreBucketTask.cs" />
     <Compile Include="S3CoreFileTask.cs" />
     <Compile Include="S3CoreTask.cs" />

--- a/S3NAntTask/S3PutFile-DEP-Task.cs
+++ b/S3NAntTask/S3PutFile-DEP-Task.cs
@@ -16,9 +16,18 @@ namespace S3NAntTask
         protected override void ExecuteTask()
         {
             // Ensure the configured bucket exists
-            if (!BucketExists())
+            if (!BucketExists(BucketName))
             {
-                Project.Log(Level.Error, "[ERROR] S3 Bucket '{0}' not found!", BucketName);
+                //Project.Log(Level.Error, "[ERROR] S3 Bucket '{0}' not found!", BucketName);
+                S3CreateBucketTask cb = new S3CreateBucketTask();
+                try
+                {
+                    cb.CreateBucket();
+                }
+                catch (Exception ex)
+                {
+                    Project.Log(Level.Error, "[ERROR] Error creating bucket. Msg: \r\n" + ex);
+                }
                 return;
             }
 
@@ -30,7 +39,7 @@ namespace S3NAntTask
             }
 
             // Ensure the overwrite is false and the file doesn't already exist in the specified bucket
-            if (!Overwrite && FileExists())
+            if (!Overwrite && FileExists(FileName))
                 return;
 
             // Send the file to S3
@@ -55,10 +64,10 @@ namespace S3NAntTask
                     ShowError(ex);
                 }
             }
-            if (!FileExists())
-                Project.Log(Level.Error, "File: {0}, failed to upload!", FileName);
+            if (!FileExists(FileName))
+                Project.Log(Level.Error, "Upload FAILED!");
             else
-                Project.Log(Level.Info, "Successfully sent file to Amazon S3: {0}", FileName);
+                Project.Log(Level.Info, "Upload successful!");
         }
 
     }

--- a/S3NAntTask/S3PutFileTask.cs
+++ b/S3NAntTask/S3PutFileTask.cs
@@ -16,7 +16,7 @@ namespace S3NAntTask
         protected override void ExecuteTask() 
         {
             // Ensure the configured bucket exists
-            if (!BucketExists())
+            if (!BucketExists(BucketName))
             {
                 Project.Log(Level.Error, "[ERROR] S3 Bucket '{0}' not found!", BucketName);
                 return;
@@ -30,7 +30,7 @@ namespace S3NAntTask
             }
 
             // Ensure the overwrite is false and the file doesn't already exist in the specified bucket
-            if (!Overwrite && FileExists())
+            if (!Overwrite && FileExists(FileName))
                 return;
 
             // Send the file to S3
@@ -55,10 +55,10 @@ namespace S3NAntTask
                     ShowError(ex);
                 }
             }
-            if (!FileExists())
-                Project.Log(Level.Error, "File: {0}, failed to upload!", FileName);
+            if (!FileExists(FileName))
+                Project.Log(Level.Error, "Upload FAILED!");
             else
-                Project.Log(Level.Info, "Successfully sent file to Amazon S3: {0}", FileName);
+                Project.Log(Level.Info, "Upload successful!");
         }
 
     }


### PR DESCRIPTION
Enhancements:
1) New Task: amazon-s3-copyFile that will allow you to copy a file between buckets within S3
2) Incorporated a string (bucketName) requirement to method BucketExists to allow for validating the existence of more than one bucket.
3) Incorporated a string (fileKey) requirement to method FileExists to allow for validating the existence of multiple filenames.
4) Formatting changes on output statements

Bug Fixes:
1) Added a test to make sure a bucket exists before attempting to delete it
2) Corrected an issue where you were unable to delete files if they were inside a sub directory of the bucket
3) Added back in the CreateBucket method to the deprecated 'amazon-s3' Task to more closely mimic the original behavior of this Task
